### PR TITLE
specify data.table's melt

### DIFF
--- a/R/calcLocEnrichment.R
+++ b/R/calcLocEnrichment.R
@@ -98,7 +98,7 @@ redefineUserSets=FALSE) {
 	universeLength = length(userUniverse)
 
 	# To build the fisher matrix, support is 'a'
-	scoreTable = data.table(melt(t(olmat), variable.factor=FALSE))
+	scoreTable = data.table(data.table::melt(t(olmat), variable.factor=FALSE))
 	setnames(scoreTable, c("Var1", "Var2", "value"), c("userSet", "dbSet", "support"))
 
 	# reshape2 has an annoying habit of converting strings into factors, which


### PR DESCRIPTION
Fixes error `Items of 'old' not found in column names` caused if `reshape2` is loaded after `data.table`, after `melt` was moved into `data.table`.